### PR TITLE
Removed retyping of company ID to integer

### DIFF
--- a/ares_util/ares.py
+++ b/ares_util/ares.py
@@ -22,7 +22,7 @@ def call_ares(company_id):
         >>> call_ares(invalid_company_id)
         False
 
-        >>> valid_company_id = 27074358
+        >>> valid_company_id = "27074358"
         >>> returned_dict = call_ares(valid_company_id)
         >>> returned_dict['legal']['company_id'] == valid_company_id
         True
@@ -59,7 +59,7 @@ def call_ares(company_id):
     result_company_info = {
         'legal': {
             'company_name': get_text_value(company_record.get('D:OF', None)),
-            'company_id': int(get_text_value(company_record.get('D:ICO', None))),
+            'company_id': get_text_value(company_record.get('D:ICO', None)),
             'company_vat_id': get_text_value(company_record.get('D:DIC', None)),
             'legal_form': get_legal_form(company_record.get('D:PF', None))
         },


### PR DESCRIPTION
Retyping of company ID to integer may cause problems with IDs which have leading zeros (the zeros get trimmed). Having different ID on output than on input causes inconsistency. E.g. if the TIN was 02920129, one would get 2920129. We should probably think about the ID as a string (like VAT ID).
