### PR TITLE
AresConnectionError thrown on connection errors

### DIFF
--- a/ares_util/ares.py
+++ b/ares_util/ares.py
@@ -13,7 +13,7 @@ import xmltodict
 from .settings import ARES_API_URL, COMPANY_ID_LENGTH
 
 from .helpers import normalize_company_id_length
-from .exceptions import InvalidCompanyIDError, AresNoResponseError
+from .exceptions import InvalidCompanyIDError, AresNoResponseError, AresConnectionError
 
 
 def call_ares(company_id):
@@ -40,7 +40,15 @@ def call_ares(company_id):
         return False
 
     params = urllib.urlencode({'ico': company_id})
-    response = urllib2.urlopen(ARES_API_URL + "?%s" % params)
+
+    try:
+        response = urllib2.urlopen(ARES_API_URL + "?%s" % params)
+    except urllib2.HTTPError as e:
+        raise AresConnectionError('HTTPError ' + str(e.code))
+    except urllib2.URLError as e:
+        raise AresConnectionError('URLError, ' + str(e.reason))
+    except Exception as e:
+        raise AresConnectionError('Exception, ' + str(e))
 
     if response.getcode() != 200:
         raise AresNoResponseError()

--- a/ares_util/exceptions.py
+++ b/ares_util/exceptions.py
@@ -10,3 +10,6 @@ class InvalidCompanyIDError(Exception):
 
 class AresNoResponseError(Exception):
     pass
+
+class AresConnectionError(Exception):
+    pass

--- a/ares_util/tests/ares_test.py
+++ b/ares_util/tests/ares_test.py
@@ -6,7 +6,9 @@ from __future__ import unicode_literals
 from unittest2 import TestCase
 
 from ..ares import call_ares, get_legal_form
+from .. import ares
 from ..helpers import normalize_company_id_length
+from ..exceptions import AresConnectionError
 
 
 class CallARESTestCase(TestCase):
@@ -27,7 +29,6 @@ class CallARESTestCase(TestCase):
         self.assertEqual(ares_response['legal']['company_name'], "České vysoké učení technické v Praze")
         self.assertEqual(ares_response['address']['street'], "Zikova 1903/4")
 
-
     def test_valid_values(self):
         other_valid_company_ids = ('62739913', '25063677', '1603094', '01603094', '27074358')
 
@@ -37,6 +38,12 @@ class CallARESTestCase(TestCase):
                 self.assertEqual(normalize_company_id_length(one_id), ares_data['legal']['company_id'])
         except KeyError as error:
             self.fail(error)
+
+    def test_raises_ares_connection_exception(self):
+        correct_url = ares.ARES_API_URL
+        ares.ARES_API_URL = 'http://nonsenseurl.nonsence'
+        self.assertRaises(AresConnectionError, call_ares, company_id='62739913')
+        ares.ARES_API_URL = correct_url
 
 
 class LegalFormTest(TestCase):


### PR DESCRIPTION
All the exceptions thrown by urllib2.urlopen are caught and more general AresConnectionError is raised instead.