### PR TITLE
Fixed Key Error when ARES returned server fault instead of valid response

### DIFF
--- a/ares_util/exceptions.py
+++ b/ares_util/exceptions.py
@@ -14,3 +14,13 @@ class AresNoResponseError(Exception):
 
 class AresConnectionError(Exception):
     pass
+
+
+class AresServerError(Exception):
+    def __init__(self, fault_code, fault_message):
+        super(AresServerError, self).__init__(fault_code, fault_message)
+        self.fault_code = fault_code
+        self.fault_message = fault_message
+
+    def __repr__(self):
+        return 'AresServerError, {}, {}'.format(self.fault_code, self.fault_message)

--- a/tests/responses/server_fault.xml
+++ b/tests/responses/server_fault.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<are:Ares_odpovedi xmlns:are="http://wwwinfo.mfcr.cz/ares/xml_doc/schemas/ares/ares_answer_basic/v_1.0.3" xmlns:D="http://wwwinfo.mfcr.cz/ares/xml_doc/schemas/ares/ares_datatypes/v_1.0.3"
+                   xmlns:U="http://wwwinfo.mfcr.cz/ares/xml_doc/schemas/uvis_datatypes/v_1.0.3" odpoved_datum_cas="2016-04-30T14:12:58" odpoved_pocet="1" odpoved_typ="Basic" vystup_format="XML"
+                   xslt="klient" validation_XSLT="http://wwwinfo.mfcr.cz/ares/xml_doc/schemas/ares/ares_odpovedi.xsl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://wwwinfo.mfcr.cz/ares/xml_doc/schemas/ares/ares_answer_basic/v_1.0.3 http://wwwinfo.mfcr.cz/ares/xml_doc/schemas/ares/ares_answer_basic/v_1.0.3/ares_answer_basic_v_1.0.3.xsd"
+                   Id="ares">
+    <are:Fault>
+        <faultcode>Server.Service</faultcode>
+        <faultstring>obecná chyba serverové služby</faultstring>
+    </are:Fault>
+</are:Ares_odpovedi>


### PR DESCRIPTION
Prevent raise Key Error when Ares return `Fault` element

**GitHub issue**
#44 